### PR TITLE
fix Client.__init__() missing 1 intents error

### DIFF
--- a/SCPSL-Discord-Bot/bot.py
+++ b/SCPSL-Discord-Bot/bot.py
@@ -7,7 +7,7 @@ from discord.ext import commands
 id  = ""
 api = ""
 
-bot = commands.Bot(command_prefix="!")
+bot = commands.Bot(command_prefix="!", intents=discord.Intents.none())
 @bot.event
 async def on_ready():
     print("The bot is running.")
@@ -20,3 +20,4 @@ async def on_ready():
 
 
 bot.run("Token")
+


### PR DESCRIPTION
HI
I got bellow error when I tried to run the bot:
```BotBase.__init__() missing 1 required keyword-only argument: 'intents'```
and here is the fix 